### PR TITLE
correct github language markers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+templates/*
+*/*.yml linguist-detectable=True


### PR DESCRIPTION
Github flags the project as 100% shell script even though it's primarily YAML. Attempt to adjust this.